### PR TITLE
Cloudsdk 136

### DIFF
--- a/lib/actions/BackendAction.js
+++ b/lib/actions/BackendAction.js
@@ -199,7 +199,7 @@ class BackendAction {
     if (!pipeline || !pipeline.pipeline || !pipeline.pipeline.id) throw new Error(`invalid pipeline; check the pipeline.id property in ${file}`)
 
     const fileName = path.basename(file, '.json')
-    if (fileName !== pipeline.pipeline.id) throw new Error('The pipeline id and the file name need to be equal! Please make sure you changed both places')
+    if (fileName !== pipeline.pipeline.id) throw new Error(`Pipeline ID "${pipeline.pipeline.id}" should match its file name!`)
 
     if (!this.pipelines[file]) this.pipelines[file] = {}
     this.pipelines[file].id = pipeline.pipeline.id

--- a/lib/actions/BackendAction.js
+++ b/lib/actions/BackendAction.js
@@ -264,12 +264,28 @@ class BackendAction {
       const pipelinesFiles = await fsEx.readdir(pipelineFolder)
       const promises = []
 
-      // read pipelines and group them by trusted
+      // read pipelines
       for (let index in pipelinesFiles) promises.push(fsEx.readJSON(path.join(pipelineFolder, pipelinesFiles[index])))
+
+      // once loaded, validate pipeline IDs vs pipeline file names; should be the same for each
+      const loadedPipelines = await Promise.all(promises)
+      let pipelineFileNameMismatches = []
+      loadedPipelines.forEach((pipeline, index) => {
+        if (pipeline.pipeline.id !== path.basename(pipelinesFiles[index], '.json')) {
+          pipelineFileNameMismatches.push(
+            `Pipeline ID "${pipeline.pipeline.id}" and file name "${path.basename(pipelinesFiles[index], '.json')}" mismatch! ` +
+            'The ID of a pipeline and its file name should be the same.'
+          )
+        }
+      })
+
+      if (pipelineFileNameMismatches.length > 0) throw new Error(pipelineFileNameMismatches.join('\n'))
+
+      // group pipelines by trusted / untrusted
       if (extension.trusted === true) {
-        trustedPipelines = trustedPipelines.concat(await Promise.all(promises))
+        trustedPipelines = trustedPipelines.concat(loadedPipelines)
       } else {
-        pipelines = pipelines.concat(await Promise.all(promises))
+        pipelines = pipelines.concat(loadedPipelines)
       }
     }
     await Promise.all([

--- a/test/actions/BackendAction-test.js
+++ b/test/actions/BackendAction-test.js
@@ -285,7 +285,7 @@ describe('BackendAction', () => {
         assert.ifError(err)
         backendAction._pipelineChanged(file).catch(err => {
           assert.ok(err)
-          assert.equal(err.message, 'The pipeline id and the file name need to be equal! Please make sure you changed both places')
+          assert.equal(err.message, `Pipeline ID "${pipeline.pipeline.id}" should match its file name!`)
           done()
         })
       })

--- a/test/actions/BackendAction-test.js
+++ b/test/actions/BackendAction-test.js
@@ -173,6 +173,51 @@ describe('BackendAction', () => {
         })
     })
 
+    it('should fail when pipeline IDs not matching pipeline file names', (done) => {
+      appSettings.loadAttachedExtensions = () => { return {testExtension: {path: '..'}} }
+
+      backendAction.backendProcess = {
+        connect: sinon.stub().resolves(),
+        selectApplication: sinon.stub().resolves(),
+        resetPipelines: sinon.stub().resolves(),
+        startStepExecutor: sinon.stub().resolves(),
+        reloadPipelineController: sinon.stub().resolves()
+      }
+
+      backendAction.dcClient = {
+        downloadPipelines: sinon.stub().resolves([]),
+        removePipeline: sinon.stub().resolves(),
+        uploadMultiplePipelines: sinon.stub().resolves()
+      }
+
+      backendAction.attachedExtensionsWatcher = {
+        attachedExtensions: [{'testPipeline123': {path: ''}}],
+        start: () => sinon.stub().resolves(),
+        on: () => sinon.stub().resolves()
+      }
+
+      backendAction._extensionChanged = sinon.stub().resolves()
+
+      fsEx.writeJson(path.join(process.env.APP_PATH, 'pipelines', 'testPipeline.json'), {pipeline: {id: 'testPipeline123'}}, err => {
+        assert.ifError(err)
+
+        backendAction._startSubProcess()
+          .then(() => fsEx.readJson(path.join(process.env.APP_PATH, 'pipelines', 'testPipeline.json')))
+          .then((content) => {
+            assert.deepEqual(content, {pipeline: {id: 'testPipeline123'}})
+          })
+          .catch(err => {
+            assert.ok(err)
+            assert.equal(
+              err.message,
+              'Pipeline ID "testPipeline123" and file name "testPipeline" mismatch! ' +
+              'The ID of a pipeline and its file name should be the same.'
+            )
+            done()
+          })
+      })
+    })
+
     it('should call dcClient if pipelines were updated', (done) => {
       backendAction.backendProcess = {
         connect: sinon.stub().resolves(),


### PR DESCRIPTION
CLOUDSDK-136 Changed error message to point out the difference that's causing an error.
CLOUDSDK-136 Added validation of pipeline ID vs pipeline file name on backend start.